### PR TITLE
Use golangci-lint on GitHub Actions not Wercker

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,14 @@
+name: golangci-lint
+on:
+  workflow_dispatch:
+  push:
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.40.0

--- a/browser/browser.go
+++ b/browser/browser.go
@@ -344,8 +344,8 @@ func (bow *Browser) Forms() []Submittable {
 	}
 
 	forms := make([]Submittable, len)
-	sel.Each(func(_ int, s *goquery.Selection) {
-		forms = append(forms, NewForm(bow, s))
+	sel.Each(func(i int, s *goquery.Selection) {
+		forms[i] = NewForm(bow, s)
 	})
 	return forms
 }

--- a/wercker.yml
+++ b/wercker.yml
@@ -5,15 +5,6 @@ box:
 build:
   steps:
     - script:
-        name: install linter
-        code: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
-    - script:
-        name: lint check
-        cwd: $WERCKER_SOURCE_DIR
-        code: |
-          golangci-lint run
-    - script:
         name: go vet
         cwd: $WERCKER_SOURCE_DIR
         code: |


### PR DESCRIPTION
https://github.com/pacificporter/kanzashi2-plan/issues/1931

* CI での golangci-lint を GitHub Actions で行うよう変更しました (公式ドキュメントで推奨されてる方法)
* GitHub Actions に lint を切り分けることで Wercker と並行して処理されるので多少 CI が高速化されると思います