### PR TITLE
pacificporter/golang:1.18.5-14.20.0-2 を利用する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
     # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
     # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
     docker:
-      - image: pacificporter/golang:1.17.7-14.15.4-2
+      - image: pacificporter/golang:1.18.5-14.20.0-2
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_PASSWORD


### PR DESCRIPTION
no-bump-version ラベルを追加しました