### PR TITLE
deps: use pacificporter/golang:1.20.5-bullseye-16.20.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
     # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
     # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
     docker:
-      - image: pacificporter/golang:1.20.5-16.20.1
+      - image: pacificporter/golang:1.20.5-bullseye-16.20.1
         auth:
           username: $DOCKER_HUB_USERNAME
           password: $DOCKER_HUB_PASSWORD


### PR DESCRIPTION
- https://github.com/pacificporter/kanzashi2-plan/issues/2995

よろしくお願いします。

----

Ubuntu 18.04 は利用していないようです。

```sh
$ git grep -i ubuntu
.github/workflows/actionlint.yml:    runs-on: ubuntu-20.04
.github/workflows/create_release.yml:    runs-on: ubuntu-20.04
.github/workflows/golangci-lint.yml:    runs-on: ubuntu-20.04
agent/agent_test.go:      OSName = "Ubuntu"
agent/agent_test.go:      ut.AssertEquals("Mozilla/5.0 (Ubuntu 14.04; X11; like Gecko) Chrome/37.0.2049.0 Safari/537.36", Create())
agent/agent_test.go:      OSName = "Ubuntu"
agent/agent_test.go:      ut.AssertEquals("Mozilla/5.0 (Ubuntu 14.04) Chrome/37.0.2049.0 Safari/537.36", Create())
agent/agent_test.go:      ut.AssertEquals("Mozilla/5.0 (Ubuntu 14.04; x64; rv:31.0) Gecko/20100101 Firefox/31.0", Create())
```